### PR TITLE
Delete User REST API

### DIFF
--- a/src/main/java/net/javaguides/springboot/controller/UserController.java
+++ b/src/main/java/net/javaguides/springboot/controller/UserController.java
@@ -47,4 +47,11 @@ public class UserController {
         User updatedUser = userService.updateUser(user);
         return new ResponseEntity<>(updatedUser, HttpStatus.OK);
     }
+
+    // build delete User REST API
+    @DeleteMapping("{id}")
+    public ResponseEntity<String> deleteUser(@PathVariable("id") Long userId){
+        userService.deleteUser(userId);
+        return new ResponseEntity<>("User successfully deleted!", HttpStatus.OK);
+    }
 }

--- a/src/main/java/net/javaguides/springboot/service/UserService.java
+++ b/src/main/java/net/javaguides/springboot/service/UserService.java
@@ -12,4 +12,6 @@ public interface UserService {
     List<User> getAllUsers();
 
     User updateUser(User user);
+
+    void deleteUser(Long userId);
 }

--- a/src/main/java/net/javaguides/springboot/service/impl/UserServiceImpl.java
+++ b/src/main/java/net/javaguides/springboot/service/impl/UserServiceImpl.java
@@ -39,4 +39,9 @@ public class UserServiceImpl implements UserService {
         User updatedUser = userRepository.save(existingUser);
         return updatedUser;
     }
+
+    @Override
+    public void deleteUser(Long userId) {
+        userRepository.deleteById(userId);
+    }
 }


### PR DESCRIPTION
UserService 인터페이스에서 deleteUser 메서드를 정의.

UserServiceImpl 클래스에서 deleteUser 메서드를 구현:  userRepository.deleteById메서드를 호출해 userId를 전달해 기존 User를 삭제.

 UserController에서  User개체를 삭제한 다음 상태코드와 함께 삭제완료 메시지를 반환하는 deleteUser 메서드 생성.

 postman, DBeaver에서 상태코드 및 삭제가 잘 되는지 확인하였음.