### PR TITLE
[#12][refactor]Refactor Get All Users REST API to use DTO

### DIFF
--- a/src/main/java/net/javaguides/springboot/controller/UserController.java
+++ b/src/main/java/net/javaguides/springboot/controller/UserController.java
@@ -35,8 +35,8 @@ public class UserController {
     // build get all User REST API
     // http://localhost:8080/api/users
     @GetMapping()
-    public ResponseEntity<List<User>> getAllUsers(){
-        List<User> users = userService.getAllUsers();
+    public ResponseEntity<List<UserDto>> getAllUsers(){
+        List<UserDto> users = userService.getAllUsers();
         return new ResponseEntity<>(users, HttpStatus.OK);
     }
 

--- a/src/main/java/net/javaguides/springboot/service/UserService.java
+++ b/src/main/java/net/javaguides/springboot/service/UserService.java
@@ -10,7 +10,7 @@ public interface UserService {
 
     UserDto getUserById(Long userId);
 
-    List<User> getAllUsers();
+    List<UserDto> getAllUsers();
 
     User updateUser(User user);
 

--- a/src/main/java/net/javaguides/springboot/service/impl/UserServiceImpl.java
+++ b/src/main/java/net/javaguides/springboot/service/impl/UserServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -38,8 +39,10 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public List<User> getAllUsers() {
-        return userRepository.findAll();
+    public List<UserDto> getAllUsers() {
+        List<User> users = userRepository.findAll();
+        return users.stream().map(UserMapper::mapToUserDto)
+                .collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
- userController의 getAllUsers 메서드의 반환 유형을 User JPA Entity에서 UserDto로 변경

- UserService 인터페이스에서 getAllUsers 메서드의 반환 유형을 User JPA Entity에서 UserDto로 변경

- UserServiceImpl 클래스에서 getAllUsers 메서드의 반환 유형을 User JPA Entity에서 UserDto로 변경하고 User 목록을 UserDto목록으로 변환해서 반환받기 위해서 stream().map(UserMapper::mapToUserDto)를 통해 mapToUserDto 메서드를 호출하고 결과를 목록으로 수집하기 위해 collect(Collectors.toList()를 사용